### PR TITLE
Update examples with 0.8.0 version

### DIFF
--- a/examples/aws_array/main.tf
+++ b/examples/aws_array/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
         cbs = {
             source = "PureStorage-OpenConnect/cbs"
-            version = "~> 0.7.0"
+            version = "~> 0.8.0"
         }
     }
 }

--- a/examples/azure_array/main.tf
+++ b/examples/azure_array/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
         cbs = {
             source = "PureStorage-OpenConnect/cbs"
-            version = "~> 0.7.0"
+            version = "~> 0.8.0"
         }
     }
 }

--- a/examples/azure_fusion_sec/main.tf
+++ b/examples/azure_fusion_sec/main.tf
@@ -2,7 +2,7 @@ terraform {
     required_providers {
         cbs = {
             source = "PureStorage-OpenConnect/cbs"
-            version = "~> 0.7.0"
+            version = "~> 0.8.0"
         }
     }
 }


### PR DESCRIPTION
The examples should reference the latest available version of the terraform provider